### PR TITLE
Fix/GameSystem: 버그 수정(틀린 규칙, Reset)

### DIFF
--- a/Source/Endless_Hotel/Actor/Elevator/Elevator.cpp
+++ b/Source/Endless_Hotel/Actor/Elevator/Elevator.cpp
@@ -279,6 +279,10 @@ void AElevator::StartElevator()
         {
             LinkedEntrance->SetTriggerActive();
         }
+        if (InsideButton.IsValid())
+        {
+            InsideButton->CanPressButton(true);
+        }
         LeftDoor->SetLightingChannels(false, true, false);
         RightDoor->SetLightingChannels(false, true, false);
         SetLightOn(true);

--- a/Source/Endless_Hotel/Actor/Elevator/Elevator_Button.cpp
+++ b/Source/Endless_Hotel/Actor/Elevator/Elevator_Button.cpp
@@ -47,7 +47,10 @@ void AElevator_Button::BeginPlay()
 
 void AElevator_Button::Reset()
 {
-    Component_Interact->ActiveInteract(true);
+    if(bCanPress_)
+    {
+        Component_Interact->ActiveInteract(true);
+    }
 }
 
 #pragma endregion
@@ -61,6 +64,7 @@ void AElevator_Button::Interact(AEHCharacter* Interacter)
 
 void AElevator_Button::CanPressButton(bool bCanPress)
 {
+    this->bCanPress_ = bCanPress;
     if(!bCanPress)
     {
         Component_Interact->ShowInteracting(false);

--- a/Source/Endless_Hotel/Actor/Elevator/Elevator_Button.h
+++ b/Source/Endless_Hotel/Actor/Elevator/Elevator_Button.h
@@ -51,6 +51,9 @@ public:
 public:
     void Reset();
 
+private:
+    bool bCanPress_;
+
 #pragma endregion
 
 #pragma region Interact

--- a/Source/Endless_Hotel/Actor/Interact/Acquire/ManualFragment/ManualFragment.cpp
+++ b/Source/Endless_Hotel/Actor/Interact/Acquire/ManualFragment/ManualFragment.cpp
@@ -35,6 +35,14 @@ void AManualFragment::BeginPlay()
 	}
 }
 
+void AManualFragment::EndPlay(EEndPlayReason::Type EndPlayReason)
+{
+	auto* VerdictSubsystem = GetGameInstance()->GetSubsystem<UAnomalyVerdictSubsystem>();
+	VerdictSubsystem->OnAnomalySpawned.RemoveAll(this);
+
+	Super::EndPlay(EndPlayReason);
+}
+
 #pragma endregion
 
 #pragma region Acquire

--- a/Source/Endless_Hotel/Actor/Interact/Acquire/ManualFragment/ManualFragment.h
+++ b/Source/Endless_Hotel/Actor/Interact/Acquire/ManualFragment/ManualFragment.h
@@ -20,6 +20,7 @@ public:
 
 protected:
     virtual void BeginPlay() override;
+    virtual void EndPlay(EEndPlayReason::Type EndPlayReason) override;
 
 #pragma endregion
 

--- a/Source/Endless_Hotel/Actor/RoomSign/RoomSignActor.cpp
+++ b/Source/Endless_Hotel/Actor/RoomSign/RoomSignActor.cpp
@@ -21,6 +21,13 @@ void ARoomSignActor::BeginPlay()
 	Sub->FloorChange_Reset.AddUObject(this, &ThisClass::Reset);
 }
 
+void ARoomSignActor::EndPlay(EEndPlayReason::Type EndPlayReason)
+{
+	auto* Sub = GetGameInstance()->GetSubsystem<UFloorProgressSubsystem>();
+	Sub->FloorChange_Reset.RemoveAll(this);
+	Super::EndPlay(EndPlayReason);
+}
+
 #pragma endregion
 
 #pragma region Reset

--- a/Source/Endless_Hotel/Actor/RoomSign/RoomSignActor.h
+++ b/Source/Endless_Hotel/Actor/RoomSign/RoomSignActor.h
@@ -52,6 +52,7 @@ public:
 
 protected:
 	virtual void BeginPlay() override;
+	virtual void EndPlay(EEndPlayReason::Type EndPlayReason) override;
 
 #pragma endregion
 

--- a/Source/Endless_Hotel/Anomaly/Generator/Anomaly_Generator.cpp
+++ b/Source/Endless_Hotel/Anomaly/Generator/Anomaly_Generator.cpp
@@ -71,6 +71,7 @@ void AAnomaly_Generator::SpawnAnomaly()
 		CurrentData.AnomalyID = NormalData.ID;
 		CurrentData.DataLayer = NormalData.DataLayer;
 		CurrentData.EventClass = NormalData.Event;
+		CurrentData.Rule = NormalData.Rule;
 	}
 	UEHGameInstance* GameInstance = GetWorld()->GetGameInstance<UEHGameInstance>();
 	CurrentAnomaly = SpawnFromInfo(CurrentData, GetLevel());
@@ -140,6 +141,7 @@ AAnomaly_Event* AAnomaly_Generator::SpawnFromInfo(const FAnomalySpawnInfo& Info,
 	if (Spawned)
 	{
 		Spawned->AnomalyID = Info.AnomalyID;
+		Spawned->Rule = Info.Rule;
 	}
 	return Spawned;
 }

--- a/Source/Endless_Hotel/Anomaly/Object/Anomaly_Object_Base.cpp
+++ b/Source/Endless_Hotel/Anomaly/Object/Anomaly_Object_Base.cpp
@@ -28,16 +28,14 @@ void AAnomaly_Object_Base::BeginPlay()
 
     OriginalTransform = GetActorTransform();
     
-    auto* FloorSub = GetGameInstance()->GetSubsystem<UFloorProgressSubsystem>();
     auto* AnomalySub = GetGameInstance()->GetSubsystem<UAnomalyPoolSubsystem>();
-    ResetHandle = FloorSub->FloorChange_Reset.AddUObject(this, &ThisClass::Reset);
     AnomalySub->RegisterAnomalyObject(this);
 }
 
 void AAnomaly_Object_Base::EndPlay(EEndPlayReason::Type EndPlayReason)
 {
-    auto* FloorSub = GetGameInstance()->GetSubsystem<UFloorProgressSubsystem>();
-    FloorSub->FloorChange_Reset.Remove(ResetHandle);
+    auto* AnomalySub = GetGameInstance()->GetSubsystem<UAnomalyPoolSubsystem>();
+    AnomalySub->UnRegisterAnomalyObject(this);
 
     SetActorTransform(OriginalTransform);
 

--- a/Source/Endless_Hotel/Anomaly/Object/EightExit/Light/Anomaly_Object_Light.cpp
+++ b/Source/Endless_Hotel/Anomaly/Object/EightExit/Light/Anomaly_Object_Light.cpp
@@ -34,11 +34,11 @@ void AAnomaly_Object_Light::Reset()
 	Object->SetVisibility(true);
 
 	// 임시
-	/*Mesh_Destroy->DestroyComponent();
+	Mesh_Destroy->DestroyComponent();
 	Mesh_Destroy = NewObject<UGeometryCollectionComponent>(this);
 	Mesh_Destroy->AttachToComponent(Object, FAttachmentTransformRules::KeepRelativeTransform);
 	Mesh_Destroy->RegisterComponent();
-	Mesh_Destroy->SetRestCollection(GC_Light);*/
+	Mesh_Destroy->SetRestCollection(GC_Light);
 
 	SetGeometryCollection();
 

--- a/Source/Endless_Hotel/GameSystem/GameInstance/EHGameInstance.cpp
+++ b/Source/Endless_Hotel/GameSystem/GameInstance/EHGameInstance.cpp
@@ -45,11 +45,11 @@ void UEHGameInstance::QuitGame()
 
 #pragma region Data Layer
 
-void UEHGameInstance::SwitchDataLayer(const EMapDataLayer& TargetDataLayer, bool bNotifyDelegate)
+bool UEHGameInstance::SwitchDataLayer(const EMapDataLayer& TargetDataLayer, bool bNotifyDelegate)
 {
 	if (CurrentDataLayer == TargetDataLayer)
 	{
-		return;
+		return false;
 	}
 
 	UDataLayerAsset* DLA_Active = GetDataLayerAsset(TargetDataLayer);
@@ -69,6 +69,7 @@ void UEHGameInstance::SwitchDataLayer(const EMapDataLayer& TargetDataLayer, bool
 	{
 		OnDataLayerChanged.Broadcast(CurrentDataLayer);
 	}
+	return true;
 }
 
 void UEHGameInstance::ActiveAdditionalDataLayer(const EMapDataLayer& TargetDataLayer, bool bActive)

--- a/Source/Endless_Hotel/GameSystem/GameInstance/EHGameInstance.h
+++ b/Source/Endless_Hotel/GameSystem/GameInstance/EHGameInstance.h
@@ -38,7 +38,7 @@ protected:
 #pragma region Data Layer
 
 public:
-	void SwitchDataLayer(const EMapDataLayer& TargetDataLayer, bool bNotifyDelegate = true);
+	bool SwitchDataLayer(const EMapDataLayer& TargetDataLayer, bool bNotifyDelegate = true);
 	void ActiveAdditionalDataLayer(const EMapDataLayer& TargetDataLayer, bool bActive);
 
 	const EMapDataLayer& GetCurrentDataLayer() { return CurrentDataLayer; }

--- a/Source/Endless_Hotel/GameSystem/SubSystem/AnomalyPoolSubsystem.cpp
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/AnomalyPoolSubsystem.cpp
@@ -82,10 +82,11 @@ void UAnomalyPoolSubsystem::RegisterAnomalyObject(AAnomaly_Object_Base* Object)
     UClass* ActorClass = Object->GetClass();
     AnomalyObjectPool.FindOrAdd(ActorClass).Objects.AddUnique(Object);
 
-	UFloorProgressSubsystem* FloorSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UFloorProgressSubsystem>() : nullptr;
+    UFloorProgressSubsystem* FloorSys = GetGameInstance()->GetSubsystem<UFloorProgressSubsystem>();
 	if (FloorSys)
 	{
-		FloorSys->FloorChange_Reset.AddUObject(Object, &AAnomaly_Object_Base::Reset);
+        FDelegateHandle Handle = FloorSys->FloorChange_Reset.AddUObject(Object, &AAnomaly_Object_Base::Reset);
+        ResetHandles.Add(Object, Handle);
 	}
 
     const UDataLayerStreamingSubsystem* DataLayerSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UDataLayerStreamingSubsystem>() : nullptr;
@@ -102,6 +103,13 @@ void UAnomalyPoolSubsystem::UnRegisterAnomalyObject(AAnomaly_Object_Base* Object
         return;
     }
 
+    FDelegateHandle* Handle = ResetHandles.Find(Object);
+    UFloorProgressSubsystem* FloorSys = GetGameInstance()->GetSubsystem<UFloorProgressSubsystem>();
+    {
+        FloorSys->FloorChange_Reset.Remove(*Handle);
+    }
+    ResetHandles.Remove(Object);
+
     UClass* TargetClass = Object->GetClass();
     if (FAnomalyObjectArray* FoundStruct = AnomalyObjectPool.Find(TargetClass))
     {
@@ -111,10 +119,12 @@ void UAnomalyPoolSubsystem::UnRegisterAnomalyObject(AAnomaly_Object_Base* Object
             AnomalyObjectPool.Remove(TargetClass);
         }
 
-        UAnomalyVerdictSubsystem* VerdictSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UAnomalyVerdictSubsystem>() : nullptr;
-        if (VerdictSys && IsValid(VerdictSys->GetCurrentAnomaly()))
+        if (UAnomalyVerdictSubsystem* VerdictSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UAnomalyVerdictSubsystem>() : nullptr)
         {
-            VerdictSys->GetCurrentAnomaly()->LinkedObjects.Remove(Object);
+            if (IsValid(VerdictSys->GetCurrentAnomaly()))
+            {
+                VerdictSys->GetCurrentAnomaly()->LinkedObjects.Remove(Object);
+            }
         }
     }
 }

--- a/Source/Endless_Hotel/GameSystem/SubSystem/AnomalyPoolSubsystem.h
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/AnomalyPoolSubsystem.h
@@ -97,6 +97,9 @@ private:
 public:
     void ResetPool();
 
+private:
+    TMap<TWeakObjectPtr<class AAnomaly_Object_Base>, FDelegateHandle> ResetHandles;
+
 #pragma endregion
 
 };

--- a/Source/Endless_Hotel/GameSystem/SubSystem/AnomalyVerdictSubsystem.cpp
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/AnomalyVerdictSubsystem.cpp
@@ -26,6 +26,11 @@ void UAnomalyVerdictSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	Collection.InitializeDependency<UDataLayerStreamingSubsystem>();
 	Collection.InitializeDependency<UElevatorManagerSubsystem>();
 	Collection.InitializeDependency<UFloorProgressSubsystem>();
+
+	if (UDataLayerStreamingSubsystem* DataLayerSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UDataLayerStreamingSubsystem>() : nullptr)
+	{
+		DataLayerSys->OnDataLayerReady.AddUObject(this, &ThisClass::OnDataLayerReady);
+	}
 }
 
 #pragma endregion
@@ -209,11 +214,24 @@ void UAnomalyVerdictSubsystem::LoadNextMap()
 	}
 
 	UEHGameInstance* GameInstance = GetWorld()->GetGameInstance<UEHGameInstance>();
-	const EMapDataLayer ActualCurrentLayer = GameInstance->GetCurrentDataLayer();
-	const EMapDataLayer TargetLayer = NextAnomalyMap;
-	GameInstance->SwitchDataLayer(TargetLayer);
+	const bool bLayerChanged = GameInstance->SwitchDataLayer(NextAnomalyMap);
 
-	if (ActualCurrentLayer == TargetLayer && FloorSys)
+	if (!bLayerChanged && FloorSys)
+	{
+		FloorSys->FloorChange_Reset.Broadcast();
+	}
+}
+
+void UAnomalyVerdictSubsystem::OnDataLayerReady()
+{
+	UFloorProgressSubsystem* FloorSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UFloorProgressSubsystem>() : nullptr;
+
+	if (FloorSys && FloorSys->bIsFirstStartFloor)
+	{
+		bIsStartInBed = true;
+	}
+
+	if (FloorSys)
 	{
 		FloorSys->FloorChange_Reset.Broadcast();
 	}

--- a/Source/Endless_Hotel/GameSystem/SubSystem/AnomalyVerdictSubsystem.h
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/AnomalyVerdictSubsystem.h
@@ -71,6 +71,7 @@ public:
 	void SetCurrentAnomaly(AAnomaly_Event* Anomaly, EAnomalyID AnomalyID, EMapDataLayer AnomalyMap);
 	void SetNextAnomaly(EAnomalyID AnomalyID, EMapDataLayer AnomalyMap);
 	void LoadNextMap();
+	void OnDataLayerReady();
 	bool IsAnomalyReady() const { return bIsAnomalyReady; }
 
 	AAnomaly_Event* GetCurrentAnomaly() const { return CurrentAnomaly; }

--- a/Source/Endless_Hotel/GameSystem/SubSystem/DataLayerStreamingSubsystem.cpp
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/DataLayerStreamingSubsystem.cpp
@@ -16,9 +16,6 @@ void UDataLayerStreamingSubsystem::Initialize(FSubsystemCollectionBase& Collecti
 {
 	Super::Initialize(Collection);
 
-	Collection.InitializeDependency<UAnomalyVerdictSubsystem>();
-	Collection.InitializeDependency<UFloorProgressSubsystem>();
-
 	if (UEHGameInstance* GameInstance = Cast<UEHGameInstance>(GetGameInstance()))
 	{
 		GameInstance->OnDataLayerChanged.AddUObject(this, &ThisClass::OnChangedDataLayer);
@@ -31,17 +28,6 @@ void UDataLayerStreamingSubsystem::Initialize(FSubsystemCollectionBase& Collecti
 
 void UDataLayerStreamingSubsystem::OnChangedDataLayer(const EMapDataLayer& DataLayer)
 {
-	UAnomalyVerdictSubsystem* VerdictSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UAnomalyVerdictSubsystem>() : nullptr;
-	UFloorProgressSubsystem* FloorSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UFloorProgressSubsystem>() : nullptr;
-
-	if (FloorSys && FloorSys->bIsFirstStartFloor)
-	{
-		if (VerdictSys)
-		{
-			VerdictSys->bIsStartInBed = true;
-		}
-	}
-
 	UWorld* World = GetGameInstance() ? GetGameInstance()->GetWorld() : nullptr;
 	if (!World)
 	{
@@ -86,6 +72,7 @@ void UDataLayerStreamingSubsystem::WaitForDataLayerReady(const EMapDataLayer& Da
 			SafeWorld->GetTimerManager().ClearTimer(DataLayerStreamingCheckHandle);
 			VisitedDataLayers.Add(DataLayer);
 			CurrentDataLayer = DataLayer;
+			OnDataLayerReady.Broadcast();
 		}), 0.1f, true);
 }
 

--- a/Source/Endless_Hotel/GameSystem/SubSystem/DataLayerStreamingSubsystem.cpp
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/DataLayerStreamingSubsystem.cpp
@@ -86,12 +86,6 @@ void UDataLayerStreamingSubsystem::WaitForDataLayerReady(const EMapDataLayer& Da
 			SafeWorld->GetTimerManager().ClearTimer(DataLayerStreamingCheckHandle);
 			VisitedDataLayers.Add(DataLayer);
 			CurrentDataLayer = DataLayer;
-
-			if (UFloorProgressSubsystem* FloorSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UFloorProgressSubsystem>() : nullptr)
-			{
-				// 데이터 레이어 바뀌는 것에 층 변화 관련 델리게이트 호출이 왜 있는지 모르겟음 -> 이거 때매 자꾸 오류 남 (역할에 맞게 바인딩했는데 역할에 맞지 않게 자꾸 Broadcast 하니까 그럼)
-				//FloorSys->FloorChange_Reset.Broadcast();
-			}
 		}), 0.1f, true);
 }
 

--- a/Source/Endless_Hotel/GameSystem/SubSystem/DataLayerStreamingSubsystem.h
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/DataLayerStreamingSubsystem.h
@@ -39,6 +39,9 @@ public:
 	EMapDataLayer GetCurrentDataLayer() const { return CurrentDataLayer; }
 	void SetCurrentDataLayer(const EMapDataLayer& DataLayer) { CurrentDataLayer = DataLayer; }
 
+	DECLARE_MULTICAST_DELEGATE(FOnDataLayerStreamingReady);
+	FOnDataLayerStreamingReady OnDataLayerReady;
+
 private:
 	void WaitForDataLayerReady(const EMapDataLayer& DataLayer, bool bAlreadyRegistered);
 

--- a/Source/Endless_Hotel/GameSystem/SubSystem/FloorProgressSubsystem.cpp
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/FloorProgressSubsystem.cpp
@@ -27,16 +27,6 @@ void UFloorProgressSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 
 #pragma region Floor
 
-void UFloorProgressSubsystem::ResetFloor()
-{
-	Floor = STARTFLOOR;
-
-	if (UAnomalyVerdictSubsystem* VerdictSys = GetGameInstance() ? GetGameInstance()->GetSubsystem<UAnomalyVerdictSubsystem>() : nullptr)
-	{
-		VerdictSys->NextAnomalyMap = EMapDataLayer::Hotel;
-	}
-}
-
 void UFloorProgressSubsystem::SubFloor()
 {
 	if (Floor > 1)

--- a/Source/Endless_Hotel/GameSystem/SubSystem/FloorProgressSubsystem.h
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/FloorProgressSubsystem.h
@@ -26,7 +26,7 @@ public:
 #pragma region Floor
 
 public:
-	void ResetFloor();
+	void ResetFloor() { Floor = STARTFLOOR; }
 	void SubFloor();
 	void AddFloor();
 

--- a/Source/Endless_Hotel/GameSystem/SubSystem/GameSystem.cpp
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/GameSystem.cpp
@@ -60,7 +60,6 @@ void UGameSystem::ResetGameSystem()
 	if (UFloorProgressSubsystem* FloorSys = GameInstance->GetSubsystem<UFloorProgressSubsystem>())
 	{
 		FloorSys->ResetFloorProgress();
-		FloorSys->FloorChange_Reset.Broadcast();
 	}
 }
 

--- a/Source/Endless_Hotel/GameSystem/SubSystem/GameSystem.cpp
+++ b/Source/Endless_Hotel/GameSystem/SubSystem/GameSystem.cpp
@@ -37,11 +37,6 @@ void UGameSystem::ResetGameSystem()
 		return;
 	}
 
-	if (UFloorProgressSubsystem* FloorSys = GameInstance->GetSubsystem<UFloorProgressSubsystem>())
-	{
-		FloorSys->ResetFloorProgress();
-	}
-
 	if (UDataLayerStreamingSubsystem* DataLayerSys = GameInstance->GetSubsystem<UDataLayerStreamingSubsystem>())
 	{
 		DataLayerSys->ResetDataLayerState();
@@ -60,6 +55,12 @@ void UGameSystem::ResetGameSystem()
 	if (UAnomalyPoolSubsystem* PoolSys = GameInstance->GetSubsystem<UAnomalyPoolSubsystem>())
 	{
 		PoolSys->ResetPool();
+	}
+
+	if (UFloorProgressSubsystem* FloorSys = GameInstance->GetSubsystem<UFloorProgressSubsystem>())
+	{
+		FloorSys->ResetFloorProgress();
+		FloorSys->FloorChange_Reset.Broadcast();
 	}
 }
 


### PR DESCRIPTION
# 📜 정기 회의 43차 - 2차 PR (김경원, GameSystem)
## 🎮 핵심 기능
- 없음

## 🔮 수정 사항
- 틀린 규칙 판정 수정
- Reset 관련 수정
- 엘리베이터 버튼 이동 중 안 눌리게 수정

## 📷 참고 자료
- 없음

## 🔍 리뷰가 필요한 부분
- 틀린 규칙 판정의 경우 수정했습니다. @KaneBigNose 님께서 다시 한 번 검사해주셨으면 합니다.
- Reset의 경우 수정해놓았습니다. 이제 8층에서 한 번 더 탄다고 다시 8층 안 나옵니다.
- Light_Destroy의 경우 그냥 주석 해제했더니 잘 작동하길래 뒀습니다만 혹시나 버그가 날 수 있으니 확인이 필요합니다.

## 🐛 발견한 버그 및 ✌️ 개선 제안 사항
- 없음